### PR TITLE
use hyperquest in node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,65 @@
+var querystr = require('querystring')
+var address = require('ssb-address')
+
+var ACCESS_PATH = '/access.json'
+var AUTH_PATH = '/auth.html'
+
+module.exports = {
+  getToken: function(addr, cb) {
+    addr = address(addr)
+    var xhr = new XMLHttpRequest()
+    xhr.open('GET', addr.domain+ACCESS_PATH, true)
+    xhr.responseType = 'json'
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState == 4 && cb) {
+        var err
+        if (xhr.status < 200 || xhr.status >= 400)
+          err = new Error(xhr.status + ' ' + xhr.statusText)
+        cb(err, xhr.response)
+      }
+    }
+    xhr.send()
+  },
+  getAuthUrl: function(addr, opts) {
+    addr = address(addr)
+    opts = opts || {}
+    opts.domain = window.location.protocol + '//' + window.location.host
+    return addr.domain+AUTH_PATH+'?'+querystr.stringify(opts)
+  },
+  openAuthPopup: function(addr, opts, cb) {
+    addr = address(addr)
+    if (typeof opts == 'function') {
+      cb = opts
+      opts = null
+    }
+    cb = cb || function(){}
+    opts = opts || {}
+    opts.popup = 1
+    window.open(this.getAuthUrl(addr, opts), null)
+
+    // listen for messages from the popup
+    window.addEventListener('message', onmsg)
+    function onmsg(e) {
+      if (e.origin !== addr.domain) return
+      if (e.data == 'granted')
+        cb(null, true)
+      if (e.data == 'denied')
+        cb(null, false)
+      window.removeEventListener('message', onmsg)
+    }
+  },
+  deauth: function(addr, cb) {
+    addr = address(addr)
+    var xhr = new XMLHttpRequest()
+    xhr.open('DELETE', addr.domain+AUTH_PATH, true)
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState == 4 && cb) {
+        var err
+        if (xhr.status < 200 || xhr.status >= 400)
+          err = new Error(xhr.status + ' ' + xhr.statusText)
+        cb(err)
+      }
+    }
+    xhr.send()
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var querystr = require('querystring')
 var address = require('ssb-address')
+var hyperquest = require('hyperquest')
+var concat = require('concat-stream')
 
 var ACCESS_PATH = '/access.json'
 var AUTH_PATH = '/auth.html'
@@ -7,59 +9,30 @@ var AUTH_PATH = '/auth.html'
 module.exports = {
   getToken: function(addr, cb) {
     addr = address(addr)
-    var xhr = new XMLHttpRequest()
-    xhr.open('GET', addr.domain+ACCESS_PATH, true)
-    xhr.responseType = 'json'
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState == 4 && cb) {
-        var err
-        if (xhr.status < 200 || xhr.status >= 400)
-          err = new Error(xhr.status + ' ' + xhr.statusText)
-        cb(err, xhr.response)
-      }
-    }
-    xhr.send()
-  },
-  getAuthUrl: function(addr, opts) {
-    addr = address(addr)
-    opts = opts || {}
-    opts.domain = window.location.protocol + '//' + window.location.host
-    return addr.domain+AUTH_PATH+'?'+querystr.stringify(opts)
-  },
-  openAuthPopup: function(addr, opts, cb) {
-    addr = address(addr)
-    if (typeof opts == 'function') {
-      cb = opts
-      opts = null
-    }
-    cb = cb || function(){}
-    opts = opts || {}
-    opts.popup = 1
-    window.open(this.getAuthUrl(addr, opts), null)
-
-    // listen for messages from the popup
-    window.addEventListener('message', onmsg)
-    function onmsg(e) {
-      if (e.origin !== addr.domain) return
-      if (e.data == 'granted')
-        cb(null, true)
-      if (e.data == 'denied')
-        cb(null, false)
-      window.removeEventListener('message', onmsg)
-    }
+    var req = hyperquest.get(addr.domain + ACCESS_PATH)
+    req.setHeader('Content-Type', 'application/json')
+    req.on('response', function(res) {
+      if (res.statusCode < 200 || res.statusCode >= 400)
+        return cb(new Error(res.statusCode + ' ' + res.statusMessage))
+      res.pipe(concat(function(body) {
+        try {
+          var json = JSON.parse(body)
+          cb(null, json)
+        } catch (e) {
+          cb(new Error('Failed to parse json response'))
+        }
+      }))
+    })
+    req.on('error', cb)
   },
   deauth: function(addr, cb) {
     addr = address(addr)
-    var xhr = new XMLHttpRequest()
-    xhr.open('DELETE', addr.domain+AUTH_PATH, true)
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState == 4 && cb) {
-        var err
-        if (xhr.status < 200 || xhr.status >= 400)
-          err = new Error(xhr.status + ' ' + xhr.statusText)
-        cb(err)
-      }
-    }
-    xhr.send()
+    var req = hyperquest.delete(address(addr).domain + AUTH_PATH)
+    req.on('response', function(res) {
+      if (res.statusCode < 200 || res.statusCode >= 400)
+        return cb(new Error(res.statusCode + ' ' + res.statusMessage))
+      return cb()
+    })
+    req.on('error', cb)
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "description": "retrieve rpc-auth tokens from scuttlebot for web domains",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tape test.js"
   },
+  "browser": "browser.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/ssbc/ssb-domain-auth"
   },
   "dependencies": {
+    "concat-stream": "^1.4.7",
+    "hyperquest": "^1.0.1",
     "ssb-address": "~1.0.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
@@ -18,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/ssbc/ssb-domain-auth/issues"
   },
-  "homepage": "https://github.com/ssbc/ssb-domain-auth"
+  "homepage": "https://github.com/ssbc/ssb-domain-auth",
+  "devDependencies": {
+    "tape": "^3.5.0"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,19 @@
+var test = require('tape')
+var domain = require('./')
+
+test('that we can get a token from localhost', function(t) {
+  domain.getToken('localhost', function(err, res) {
+    t.ok(!err, 'no error')
+    t.ok(typeof res == 'object', 'result is an object')
+    t.ok(res.role, 'token object has a role')
+    t.ok(res.ts, 'token object has a timestamp')
+    t.ok(res.keyId, 'token object has a key id')
+    t.ok(res.hmac, 'token object has an hmac')
+    t.end()
+  })
+})
+
+// TODO guess we need to auth before we can deauth
+//domain.deauth('localhost', function (err, res) {
+  //console.log(err, res)
+//})


### PR DESCRIPTION
PR after some discussions with @pfraze on irc.

This allows the module to be used outside the browser, since `XMLHttpRequest` isn't available there. The reason why this change is made in this particular way is to be able to browserify the module without bloating it.

We could just use `hyperquest` as it is, since it works with browserify, but the total size is 280k compared to 8k bytes.